### PR TITLE
pref: 크리에이터 상세 조회

### DIFF
--- a/src/main/java/com/culturefinder/songdodongnae/bookmark/dto/BookmarkDto.java
+++ b/src/main/java/com/culturefinder/songdodongnae/bookmark/dto/BookmarkDto.java
@@ -1,0 +1,15 @@
+package com.culturefinder.songdodongnae.bookmark.dto;
+
+import com.culturefinder.songdodongnae.bookmark.domain.BookmarkType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+
+@Getter
+@AllArgsConstructor
+public class BookmarkDto {
+
+    private Long targetId;
+    private BookmarkType bookmarkType;
+
+}

--- a/src/main/java/com/culturefinder/songdodongnae/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/culturefinder/songdodongnae/bookmark/repository/BookmarkRepository.java
@@ -70,9 +70,10 @@ public class BookmarkRepository {
 
     public List<BookmarkDto> findAllBookmarksByUser(Long userId) {
         return em.createQuery(
-                "SELECT b.bookmarkType, b.targetId FROM Bookmark b " +
-                "WHERE b.user.id = :userId " +
-                "ORDER BY b.createdAt DESC", BookmarkDto.class)
+                "SELECT new com.culturefinder.songdodongnae.bookmark.dto.BookmarkDto(b.targetId, b.bookmarkType) " +
+                        "FROM Bookmark b " +
+                        "WHERE b.user.id = :userId " +
+                        "ORDER BY b.createdAt DESC", BookmarkDto.class)
                 .setParameter("userId", userId)
                 .getResultList();
     }

--- a/src/main/java/com/culturefinder/songdodongnae/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/culturefinder/songdodongnae/bookmark/repository/BookmarkRepository.java
@@ -2,6 +2,7 @@ package com.culturefinder.songdodongnae.bookmark.repository;
 
 import com.culturefinder.songdodongnae.bookmark.domain.Bookmark;
 import com.culturefinder.songdodongnae.bookmark.domain.BookmarkType;
+import com.culturefinder.songdodongnae.bookmark.dto.BookmarkDto;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import lombok.AllArgsConstructor;
@@ -65,5 +66,14 @@ public class BookmarkRepository {
         em.createQuery("DELETE FROM Bookmark b WHERE b.bookmarkType = :bookmarkType AND b.targetId = :targetId")
                 .setParameter("bookmarkType", bookmarkType)
                 .setParameter("targetId", targetId);
+    }
+
+    public List<BookmarkDto> findAllBookmarksByUser(Long userId) {
+        return em.createQuery(
+                "SELECT b.bookmarkType, b.targetId FROM Bookmark b " +
+                "WHERE b.user.id = :userId " +
+                "ORDER BY b.createdAt DESC", BookmarkDto.class)
+                .setParameter("userId", userId)
+                .getResultList();
     }
 }

--- a/src/main/java/com/culturefinder/songdodongnae/creator/controller/CreatorController.java
+++ b/src/main/java/com/culturefinder/songdodongnae/creator/controller/CreatorController.java
@@ -70,6 +70,19 @@ public class CreatorController {
         }
     }
 
+    @GetMapping("/{id}/v2")
+    public ResponseEntity<ResponseContainer<CreatorResDto>> getCreatorV2(
+            @Parameter(description = "크리에이터 ID", required = true) @PathVariable Long id) {
+        if (!authService.isAuthenticatedUser()) {
+            CreatorResDto dto = creatorService.getCreator(id);
+            return ResponseContainer.create(HttpStatus.OK, "크리에이터 상세 조회 성공", dto);
+        } else {
+            Long userId = authService.getAuthenticatedUserId();
+            CreatorResDto dto = creatorService.getCreatorV2(id, userId);
+            return ResponseContainer.create(HttpStatus.OK, "크리에이터 상세 조회 성공", dto);
+        }
+    }
+
     @Operation(summary = "크리에이터 수정")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "크리에이터 수정 성공", content = @Content(schema = @Schema(implementation = ResponseContainer.class))),

--- a/src/main/java/com/culturefinder/songdodongnae/creator/controller/CreatorController.java
+++ b/src/main/java/com/culturefinder/songdodongnae/creator/controller/CreatorController.java
@@ -70,19 +70,6 @@ public class CreatorController {
         }
     }
 
-    @GetMapping("/{id}/v2")
-    public ResponseEntity<ResponseContainer<CreatorResDto>> getCreatorV2(
-            @Parameter(description = "크리에이터 ID", required = true) @PathVariable Long id) {
-        if (!authService.isAuthenticatedUser()) {
-            CreatorResDto dto = creatorService.getCreator(id);
-            return ResponseContainer.create(HttpStatus.OK, "크리에이터 상세 조회 성공", dto);
-        } else {
-            Long userId = authService.getAuthenticatedUserId();
-            CreatorResDto dto = creatorService.getCreatorV2(id, userId);
-            return ResponseContainer.create(HttpStatus.OK, "크리에이터 상세 조회 성공", dto);
-        }
-    }
-
     @Operation(summary = "크리에이터 수정")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "크리에이터 수정 성공", content = @Content(schema = @Schema(implementation = ResponseContainer.class))),

--- a/src/main/java/com/culturefinder/songdodongnae/creator/domain/Creator.java
+++ b/src/main/java/com/culturefinder/songdodongnae/creator/domain/Creator.java
@@ -5,6 +5,7 @@ import com.culturefinder.songdodongnae.delicious_spot.domain.DeliciousSpot;
 import com.culturefinder.songdodongnae.festival.domain.Festival;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -42,16 +43,19 @@ public class Creator {
     @UpdateTimestamp
     private LocalDateTime updatedAt;
 
+    @BatchSize(size = 50)
     @Builder.Default
     @OneToMany(mappedBy = "creator", fetch = FetchType.LAZY,
             orphanRemoval = true, cascade = CascadeType.ALL)
     private List<Curation> curations = new ArrayList<>();
 
+    @BatchSize(size = 50)
     @Builder.Default
     @OneToMany(mappedBy = "creator", fetch = FetchType.LAZY,
             orphanRemoval = true, cascade = CascadeType.ALL)
     private List<Festival> festivals = new ArrayList<>();
 
+    @BatchSize(size = 50)
     @Builder.Default
     @OneToMany(mappedBy = "creator", fetch = FetchType.LAZY,
             orphanRemoval = true, cascade = CascadeType.ALL)

--- a/src/main/java/com/culturefinder/songdodongnae/creator/service/CreatorService.java
+++ b/src/main/java/com/culturefinder/songdodongnae/creator/service/CreatorService.java
@@ -60,7 +60,7 @@ public class CreatorService {
         return CustomPage.of(dtos, currentPage, pageSize, totalElements);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public CreatorResDto getCreator(Long id) {
         Creator findCreator = creatorRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.ENTITY_NOT_FOUND));
@@ -80,38 +80,8 @@ public class CreatorService {
         return CreatorResDto.fromEntity(findCreator, deliciousSpots, festivals, curations);
     }
 
-    @Transactional
-    public CreatorResDto getCreator(Long id, Long userId) {
-
-        Creator findCreator = creatorRepository.findById(id)
-                .orElseThrow(() -> new CustomException(ErrorCode.ENTITY_NOT_FOUND));
-
-        List<Long> targetIdsByDeliciousSpot = bookmarkRepository.findTargetIdsByUserAndType(userId, BookmarkType.DELICIOUS_SPOT);
-        Set<Long> deliciousIds = new HashSet<>(targetIdsByDeliciousSpot);
-
-        List<DeliciousSpotThumbnailResDto> deliciousSpots = findCreator.getDeliciousSpots().stream()
-                .map(deliciousSpot -> DeliciousSpotThumbnailResDto.fromEntity(deliciousSpot, findCreator.getName(), deliciousIds.contains(deliciousSpot.getId())))
-                .toList();
-
-        List<Long> targetIdsByFestival = bookmarkRepository.findTargetIdsByUserAndType(userId, BookmarkType.FESTIVAL);
-        Set<Long> festivalIds = new HashSet<>(targetIdsByFestival);
-
-        List<FestivalThumbnailResDto> festivals = findCreator.getFestivals().stream()
-                .map(festival -> FestivalThumbnailResDto.fromEntity(festival, findCreator.getName(), festivalIds.contains(festival.getId())))
-                .toList();
-
-        List<Long> targetIdsByCuration = bookmarkRepository.findTargetIdsByUserAndType(userId, BookmarkType.CURATION);
-        Set<Long> curationIds = new HashSet<>(targetIdsByCuration);
-
-        List<CurationThumbnailResDto> curations = findCreator.getCurations().stream()
-                .map(curation -> CurationThumbnailResDto.fromEntity(curation, curationIds.contains(curation.getId())))
-                .toList();
-
-        return CreatorResDto.fromEntity(findCreator, deliciousSpots, festivals, curations);
-    }
-
     @Transactional(readOnly = true)
-    public CreatorResDto getCreatorV2(Long id, Long userId) {
+    public CreatorResDto getCreator(Long id, Long userId) {
         Creator findCreator = creatorRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.ENTITY_NOT_FOUND));
 
@@ -122,13 +92,10 @@ public class CreatorService {
         Set<Long> curationIds = new HashSet<>();
 
         for (BookmarkDto bookmark : allBookmarks) {
-            BookmarkType type = bookmark.getBookmarkType();
-            Long targetId = bookmark.getTargetId();
-
-            switch (type) {
-                case DELICIOUS_SPOT -> deliciousIds.add(targetId);
-                case FESTIVAL -> festivalIds.add(targetId);
-                case CURATION -> curationIds.add(targetId);
+            switch (bookmark.getBookmarkType()) {
+                case DELICIOUS_SPOT -> deliciousIds.add(bookmark.getTargetId());
+                case FESTIVAL -> festivalIds.add(bookmark.getTargetId());
+                case CURATION -> curationIds.add(bookmark.getTargetId());
             }
         }
 

--- a/src/main/java/com/culturefinder/songdodongnae/creator/service/CreatorService.java
+++ b/src/main/java/com/culturefinder/songdodongnae/creator/service/CreatorService.java
@@ -1,6 +1,7 @@
 package com.culturefinder.songdodongnae.creator.service;
 
 import com.culturefinder.songdodongnae.bookmark.domain.BookmarkType;
+import com.culturefinder.songdodongnae.bookmark.dto.BookmarkDto;
 import com.culturefinder.songdodongnae.bookmark.repository.BookmarkRepository;
 import com.culturefinder.songdodongnae.creator.domain.Creator;
 import com.culturefinder.songdodongnae.creator.dto.CreatorReqDto;
@@ -17,18 +18,18 @@ import com.culturefinder.songdodongnae.user.domain.Role;
 import com.culturefinder.songdodongnae.user.domain.User;
 import com.culturefinder.songdodongnae.user.repository.UserRepository;
 import com.culturefinder.songdodongnae.utils.CustomPage;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+
 @Slf4j
-@Transactional
 @RequiredArgsConstructor
 @Service
 public class CreatorService {
@@ -38,6 +39,7 @@ public class CreatorService {
     private final UserRepository userRepository;
     private final BookmarkRepository bookmarkRepository;
 
+    @Transactional
     public CreatorResDto createCreator(CreatorReqDto creatorReqDto, Long userId) {
         isAdmin(userId);
 
@@ -46,6 +48,7 @@ public class CreatorService {
         return CreatorResDto.fromEntity(savedCreator);
     }
 
+    @Transactional
     public CustomPage<CreatorThumbnailResDto> getAllCreator(int currentPage, int pageSize) {
         int offset = (currentPage - 1) * pageSize;
         long totalElements = creatorRepository.countCreator();
@@ -57,6 +60,7 @@ public class CreatorService {
         return CustomPage.of(dtos, currentPage, pageSize, totalElements);
     }
 
+    @Transactional
     public CreatorResDto getCreator(Long id) {
         Creator findCreator = creatorRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.ENTITY_NOT_FOUND));
@@ -76,6 +80,7 @@ public class CreatorService {
         return CreatorResDto.fromEntity(findCreator, deliciousSpots, festivals, curations);
     }
 
+    @Transactional
     public CreatorResDto getCreator(Long id, Long userId) {
 
         Creator findCreator = creatorRepository.findById(id)
@@ -105,7 +110,44 @@ public class CreatorService {
         return CreatorResDto.fromEntity(findCreator, deliciousSpots, festivals, curations);
     }
 
+    @Transactional(readOnly = true)
+    public CreatorResDto getCreatorV2(Long id, Long userId) {
+        Creator findCreator = creatorRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.ENTITY_NOT_FOUND));
 
+        List<BookmarkDto> allBookmarks = bookmarkRepository.findAllBookmarksByUser(userId);
+
+        Set<Long> deliciousIds = new HashSet<>();
+        Set<Long> festivalIds = new HashSet<>();
+        Set<Long> curationIds = new HashSet<>();
+
+        for (BookmarkDto bookmark : allBookmarks) {
+            BookmarkType type = bookmark.getBookmarkType();
+            Long targetId = bookmark.getTargetId();
+
+            switch (type) {
+                case DELICIOUS_SPOT -> deliciousIds.add(targetId);
+                case FESTIVAL -> festivalIds.add(targetId);
+                case CURATION -> curationIds.add(targetId);
+            }
+        }
+
+        List<DeliciousSpotThumbnailResDto> deliciousSpots = findCreator.getDeliciousSpots().stream()
+                .map(deliciousSpot -> DeliciousSpotThumbnailResDto.fromEntity(deliciousSpot, findCreator.getName(), deliciousIds.contains(deliciousSpot.getId())))
+                .toList();
+
+        List<FestivalThumbnailResDto> festivals = findCreator.getFestivals().stream()
+                .map(festival -> FestivalThumbnailResDto.fromEntity(festival, findCreator.getName(), festivalIds.contains(festival.getId())))
+                .toList();
+
+        List<CurationThumbnailResDto> curations = findCreator.getCurations().stream()
+                .map(curation -> CurationThumbnailResDto.fromEntity(curation, curationIds.contains(curation.getId())))
+                .toList();
+
+        return CreatorResDto.fromEntity(findCreator, deliciousSpots, festivals, curations);
+    }
+
+    @Transactional
     public CreatorResDto updateCreator(Long id, CreatorReqDto creatorReqDto, Long userId) {
         isAdmin(userId);
         Creator findCreator = creatorRepository.findById(id)
@@ -119,6 +161,7 @@ public class CreatorService {
         return CreatorResDto.fromEntity(findCreator);
     }
 
+    @Transactional
     public CreatorResDto deleteCreator(Long id, Long userId) {
         isAdmin(userId);
         Creator findCreator = creatorRepository.findById(id)


### PR DESCRIPTION
#66 

- 북마크 한 번에 조회 후 switch로 분리
- 쿼리 7번 -> 쿼리 5번

<br>

- 응답시간: 420ms → 148ms
→ 65% 단축 (약 0.27초 더 빨라짐)
- 처리량: 533.8 → 738.3 req/sec
→ 38% 향상
